### PR TITLE
Fix tests, change Vehicle.tlm_points back to list

### DIFF
--- a/src/rocket_sim/vehicle.py
+++ b/src/rocket_sim/vehicle.py
@@ -130,9 +130,9 @@ class Vehicle:
         # We don't use it ourselves in our methods, preferring the y passed in
         # so we get the right one for each minor step.
         self.y:np.ndarray|None=None
-        self.tlm_points={}
+        self.tlm_points=[]
     def reset(self):
-        self.tlm_points={}
+        self.tlm_points=[]
         for stage in self.stages:
             stage.prop_mass=stage.prop_mass0
             stage.attached=True
@@ -186,7 +186,7 @@ class Vehicle:
         :param dt: time step size
         """
         self.tlm_point=TlmPoint(t=t,dt=dt)
-        self.tlm_points[t]=self.tlm_point
+        self.tlm_points.append(self.tlm_point)
     def finish_tlm_point(self):
         pass
 

--- a/tests/test_rocket_sim/test_drag.py
+++ b/tests/test_rocket_sim/test_drag.py
@@ -14,13 +14,13 @@ from vehicle.titan_3e_centaur import Titan3E
 
 
 def plot_tlm(vehicle:Vehicle,tc_id:int):
-    ts=np.array([t for t in vehicle.tlm_points.keys()])
-    states=np.array([tlm_point.y0 for t,tlm_point in vehicle.tlm_points.items()])
-    masses=np.array([tlm_point.mass for t,tlm_point in vehicle.tlm_points.items()])
-    a_thr_mags=np.array([vlength(tlm_point.a_thr) for t,tlm_point in vehicle.tlm_points.items()])
-    drag_mags=np.array([tlm_point.Fs[0][2] if len(tlm_point.Fs)>0 else 0.0 for t,tlm_point in vehicle.tlm_points.items()])
+    ts=np.array([tlm_point.t for tlm_point in vehicle.tlm_points])
+    states=np.array([tlm_point.y0 for tlm_point in vehicle.tlm_points])
+    masses=np.array([tlm_point.mass for tlm_point in vehicle.tlm_points])
+    a_thr_mags=np.array([vlength(tlm_point.a_thr) for tlm_point in vehicle.tlm_points])
+    drag_mags=np.array([tlm_point.Fs[0][2] if len(tlm_point.Fs)>0 else 0.0 for tlm_point in vehicle.tlm_points])
     a_drag_mags=drag_mags/masses
-    a_grav_mags=np.array([tlm_point.accs[0][2] for t,tlm_point in vehicle.tlm_points.items()])
+    a_grav_mags=np.array([tlm_point.accs[0][2] for tlm_point in vehicle.tlm_points])
     a_mags=a_thr_mags+a_drag_mags+a_grav_mags
     plt.figure("Vehicle telemetry")
     plt.subplot(4,1,1)

--- a/tests/test_rocket_sim/test_gravity.py
+++ b/tests/test_rocket_sim/test_gravity.py
@@ -13,13 +13,8 @@ from rocket_sim.universe import Universe
 from rocket_sim.vehicle import Stage, Vehicle
 
 
-def tlm(*, t: float, dt: float, y: np.ndarray, major_step: bool, vehicle: Vehicle):
-    if major_step:
-        vehicle.tlm.append((t,y.copy(),vehicle.mass(),vehicle.thrust_mag(t=t,dt=dt,y=y,major_step=False)))
-
-
 def plot_tlm(vehicle:Vehicle):
-    states=np.array([y for t,y,mass,thr_mag in vehicle.tlm])
+    states=np.array([tlm_point.y0 for t,tlm_point in vehicle.tlm_points.items()])
     plt.figure("pos")
     plt.plot(states[:,0],states[:,1],label='r')
     plt.axis('equal')
@@ -36,7 +31,7 @@ def rose():
 
     :return: A Vehicle instance representing the rose with no stages or engines.
     """
-    rose = Vehicle(stages=[Stage(dry=1, prop=0)], engines=[], extras=[tlm])
+    rose = Vehicle(stages=[Stage(dry=1, prop=0)], engines=[])
     return rose
 
 

--- a/tests/test_rocket_sim/test_gravity.py
+++ b/tests/test_rocket_sim/test_gravity.py
@@ -14,7 +14,7 @@ from rocket_sim.vehicle import Stage, Vehicle
 
 
 def plot_tlm(vehicle:Vehicle):
-    states=np.array([tlm_point.y0 for t,tlm_point in vehicle.tlm_points.items()])
+    states=np.array([tlm_point.y0 for tlm_point in vehicle.tlm_points])
     plt.figure("pos")
     plt.plot(states[:,0],states[:,1],label='r')
     plt.axis('equal')

--- a/tests/test_rocket_sim/test_vehicle.py
+++ b/tests/test_rocket_sim/test_vehicle.py
@@ -4,19 +4,15 @@ import numpy as np
 import pytest
 from matplotlib import pyplot as plt
 
-from rocket_sim.vehicle import Stage, Engine, Vehicle
+from rocket_sim.vehicle import Stage, Engine, Vehicle, kg_per_lbm, g0
 from rocket_sim.universe import ZeroGRange, TestStand
-
-lb_kg_conv=0.45359237    # this many kg in 1 lb
-g0=9.80665               # Used to convert kgf to N
-lbf_N_conv=lb_kg_conv*g0 # This many N in 1 lbf
 
 # From The Voyager Spacecraft, Gold Medal Lecture in Mech Eng, table 2 bottom line
 Voyager1WetMass=825.4
 Voyager1PropMass=103.4
 Voyager1Stage=Stage(prop=Voyager1PropMass,total=Voyager1WetMass) #dry mass and RCS prop for Voyager
 # Value from TC-7 Voyager 2 Flight Data Report, p10
-MMPMTotalMass=4470*lb_kg_conv
+MMPMTotalMass=4470*kg_per_lbm
 PMWetMass=MMPMTotalMass-Voyager1WetMass
 # Values from AIAA79-1334 Voyager Prop System, table 5
 PMPropMass=1045.9
@@ -31,16 +27,16 @@ PMEngine=Engine(PMF,PMve)
 
 
 def plot_tlm(vehicle:Vehicle):
-    ts=np.array([t for t,y,mass,thr_mag in vehicle.tlm])
-    states=np.array([y for t,y,mass,thr_mag in vehicle.tlm])
-    masses=np.array([mass for t,y,mass,thr_mag in vehicle.tlm])
-    thr_mags=np.array([thr_mag for t,y,mass,thr_mag in vehicle.tlm])
+    ts=np.array([t for t,tlm_point in vehicle.tlm_points.items()])
+    states=np.array([tlm_point.y0 for t,tlm_point in vehicle.tlm_points.items()])
+    masses=np.array([tlm_point.mass for t,tlm_point in vehicle.tlm_points.items()])
+    a_thr_mags=np.array([tlm_point.a_thr[2] for t,tlm_point in vehicle.tlm_points.items()])
     plt.figure("Time")
     plt.plot(ts,label='mass')
     plt.figure("Mass")
     plt.plot(masses,label='mass')
     plt.figure("acc")
-    plt.plot(thr_mags/masses/9.80665,label='acc')
+    plt.plot(a_thr_mags/g0,label='acc')
     plt.figure("v")
     plt.plot(states[:,5],label='vz')
     plt.figure("pos")

--- a/tests/test_rocket_sim/test_vehicle.py
+++ b/tests/test_rocket_sim/test_vehicle.py
@@ -27,10 +27,10 @@ PMEngine=Engine(PMF,PMve)
 
 
 def plot_tlm(vehicle:Vehicle):
-    ts=np.array([t for t,tlm_point in vehicle.tlm_points.items()])
-    states=np.array([tlm_point.y0 for t,tlm_point in vehicle.tlm_points.items()])
-    masses=np.array([tlm_point.mass for t,tlm_point in vehicle.tlm_points.items()])
-    a_thr_mags=np.array([tlm_point.a_thr[2] for t,tlm_point in vehicle.tlm_points.items()])
+    ts=np.array([tlm_point.t for tlm_point in vehicle.tlm_points])
+    states=np.array([tlm_point.y0 for tlm_point in vehicle.tlm_points])
+    masses=np.array([tlm_point.mass for tlm_point in vehicle.tlm_points])
+    a_thr_mags=np.array([tlm_point.a_thr[2] for tlm_point in vehicle.tlm_points])
     plt.figure("Time")
     plt.plot(ts,label='mass')
     plt.figure("Mass")

--- a/tests/test_vehicle/test_titan_3e_centaur.py
+++ b/tests/test_vehicle/test_titan_3e_centaur.py
@@ -8,41 +8,44 @@ import pytest
 import numpy as np
 from matplotlib import pyplot as plt
 
-from rocket_sim.universe import VerticalRange
-from rocket_sim.vehicle import Vehicle
+from rocket_sim.universe import VerticalRange, TestStand
+from rocket_sim.vehicle import Vehicle, g0
 from vehicle.titan_3e_centaur import Titan3E
 
 def plot_tlm(vehicle:Vehicle,tc_id:int):
-    ts=np.array([t for t,y,mass,thr_mag in vehicle.tlm])
-    states=np.array([y for t,y,mass,thr_mag in vehicle.tlm])
-    masses=np.array([mass for t,y,mass,thr_mag in vehicle.tlm])
-    thr_mags=np.array([thr_mag for t,y,mass,thr_mag in vehicle.tlm])
+    ts=np.array([t for t,tlm_point in vehicle.tlm_points.items()])
+    states=np.array([tlm_point.y0 for t,tlm_point in vehicle.tlm_points.items()])
+    masses=np.array([tlm_point.mass for t,tlm_point in vehicle.tlm_points.items()])
+    a_thr_mags=np.array([tlm_point.a_thr[2] for t,tlm_point in vehicle.tlm_points.items()])
     plt.figure("Titan3E telemetry")
     plt.subplot(2,2,1)
     plt.title("Mass")
-    plt.plot(masses,label=f'mass {tc_id}')
+    plt.plot(ts,masses,label=f'mass {tc_id}')
     plt.legend()
     plt.subplot(2,2,2)
     plt.title("acc")
-    plt.plot(thr_mags/masses/9.80665,label=f'acc {tc_id}')
+    plt.plot(ts,a_thr_mags/g0,label=f'acc {tc_id}')
     plt.legend()
     plt.subplot(2,2,3)
     plt.title("v")
-    plt.plot(states[:,5],label=f'vz {tc_id}')
+    plt.plot(ts,states[:,5],label=f'vz {tc_id}')
     plt.legend()
     plt.subplot(2,2,4)
     plt.title("pos")
-    plt.plot(states[:,2],label='rz {tc_id}')
+    plt.plot(ts,states[:,2],label='rz {tc_id}')
     plt.legend()
     plt.pause(0.1)
 
-
-def test_titan3E():
+@pytest.mark.parametrize(
+    "static",
+    [True,False]
+)
+def test_titan3E(static:bool):
     for tc_id in (6,7):
         titan3E=Titan3E(tc_id=tc_id)
         print(titan3E.stages)
         print(titan3E.engines)
-        if False:
+        if static:
             stand=TestStand(vehicles=[titan3E],fps=10)
             stand.runto(t1=130.0)
         else:

--- a/tests/test_vehicle/test_titan_3e_centaur.py
+++ b/tests/test_vehicle/test_titan_3e_centaur.py
@@ -13,10 +13,10 @@ from rocket_sim.vehicle import Vehicle, g0
 from vehicle.titan_3e_centaur import Titan3E
 
 def plot_tlm(vehicle:Vehicle,tc_id:int):
-    ts=np.array([t for t,tlm_point in vehicle.tlm_points.items()])
-    states=np.array([tlm_point.y0 for t,tlm_point in vehicle.tlm_points.items()])
-    masses=np.array([tlm_point.mass for t,tlm_point in vehicle.tlm_points.items()])
-    a_thr_mags=np.array([tlm_point.a_thr[2] for t,tlm_point in vehicle.tlm_points.items()])
+    ts=np.array([tlm_point.t for tlm_point in vehicle.tlm_points])
+    states=np.array([tlm_point.y0 for tlm_point in vehicle.tlm_points])
+    masses=np.array([tlm_point.mass for tlm_point in vehicle.tlm_points])
+    a_thr_mags=np.array([tlm_point.a_thr[2] for tlm_point in vehicle.tlm_points])
     plt.figure("Titan3E telemetry")
     plt.subplot(2,2,1)
     plt.title("Mass")


### PR DESCRIPTION
Upon review of the test_time_reverse() test, it only showed telemetry in one direction because the time reversal was perfect and the reversed points were laid down exactly on the forward points. Change this back to a list to not have this issue.