### PR TITLE
18 pitch program

### DIFF
--- a/src/guidance/orbit.py
+++ b/src/guidance/orbit.py
@@ -1,0 +1,102 @@
+"""
+Guidance programs intended to mostly be used in orbit
+
+Created: 1/22/25
+"""
+from typing import Callable
+
+import numpy as np
+from kwanmath.geodesy import llr2xyz
+from kwanmath.vector import vnormalize, vcross, vdot
+
+from rocket_sim.vehicle import Vehicle
+
+
+def prograde_guide(*,t:float,y:np.ndarray,dt:float,major_step:bool,vehicle:Vehicle):
+    # Prograde
+    return y[3:]/np.linalg.norm(y[3:])
+
+
+def inertial_guide(*,lon:float|None=None,lat:float|None=None,v:float|None=None):
+    if v is None:
+        lon=np.deg2rad(lon)
+        lat=np.deg2rad(lat)
+        v=np.array([np.cos(lon)*np.cos(lat),np.sin(lon)*np.cos(lat),np.sin(lat)])
+    def inner(*,t:float,y:np.ndarray,dt:float,major_step:bool,vehicle:Vehicle):
+        return v
+    return inner
+
+
+def yaw_rate_guide(*,r0:np.ndarray,v0:np.ndarray,dpitch:float,dyaw:float,yawrate:float,t0:float)->Callable[...,np.ndarray]:
+    # Pre-calculate as much as we can
+    # We are going to define our variation from prograde in the VNC frame:
+    #  (V)elocity vector is along first axis
+    #  (N)ormal vector is perpendicular to orbit plane and therefore parallel to r x v
+    #  (C)o-normal is perpendicular to the other two and as close to parallel to r as is reasonable.
+    # Figure these basis vectors as the appear in ICRF
+    rbar = vnormalize(r0.reshape(-1, 1))  # Just for legibility purposes -- rbar is not a basis vector.
+    vbar = vnormalize(v0.reshape(-1, 1))
+    nbar = vnormalize(vcross(rbar, vbar))
+    cbar = vnormalize(vcross(vbar, nbar))
+    assert vdot(rbar, cbar) > 0, 'cbar is the wrong direction'
+    # So each column i of a matrix is where basis vector i of the
+    # from system lands in the to system. v is VNC frame, j is ICRF/J2000 frame
+    # This way, the vector <1,0,0> in VNC is prograde, the xy(vn) plane is equatorial
+    # and a "lon/lat" vector in this frame is a yaw=lon and pitch=lat deviation
+    # from prograde.
+    Mjv = np.hstack((vbar, nbar, cbar))
+
+    def inner(*,t:float,y:np.ndarray,dt:float,major_step:bool,vehicle:Vehicle):
+        aim_v = llr2xyz(lon=dyaw+yawrate*(t-t0), lat=dpitch, r=1, deg=True)
+        aim_j = Mjv @ aim_v
+        return aim_j.reshape(-1)
+    return inner
+
+
+def dprograde_guide(*,dpitch:float,dyaw:float,pitchrate:float,t0:float)->Callable[...,np.ndarray]:
+    """
+    Guidance program that applies a pitch and yaw to prograde guidance
+    :param dpitch:
+    :param dyaw:
+    :return: guidance routine which has the given pitch and yaw offset from
+             prograde in the instantaneous VNC frame
+    """
+    def inner(*,t:float,y:np.ndarray,dt:float,major_step:bool,vehicle:Vehicle):
+        # Can't pre-calculate because we want to use instantaneous prograde direction
+        # We are going to define our variation from prograde in the VNC frame:
+        # Figure these basis vectors as the appear in ICRF
+        rbar = vnormalize(y[:3].reshape(-1, 1))  # Just for checking purposes -- rbar is not a basis vector.
+        vbar = vnormalize(y[3:].reshape(-1, 1))
+        nbar = vnormalize(vcross(rbar, vbar))
+        cbar = vnormalize(vcross(vbar, nbar))
+        # Verify that cbar is roughly up
+        assert vdot(rbar, cbar) > 0, 'cbar is the wrong direction'
+        # So each column i of a matrix is where basis vector i of the
+        # from system lands in the to system. v is VNC frame, j is ICRF/J2000 frame
+        # This way, the vector <1,0,0> in VNC is prograde, the xy(vn) plane is equatorial
+        # and a "lon/lat" vector in this frame is a yaw=lon and pitch=lat deviation
+        # from prograde.
+        Mjv = np.hstack((vbar, nbar, cbar))
+        aim_v = llr2xyz(lon=dyaw, lat=dpitch+pitchrate*(t-t0), r=1, deg=True)
+        aim_j = Mjv @ aim_v
+        return aim_j.reshape(-1)
+    return inner
+
+
+def seq_guide(guides:dict[float,Callable[...,np.ndarray]]):
+    """
+    Create a guidance program that sequences a bunch of separate guidance programs
+    :param guides: The key is the time that the attached program switches off, the value
+                   is the guidance program active before this time. The last one might
+                   as well be active until float('inf').
+    :return:
+    """
+    t1s=[k for k,v in guides.items()]
+    t0s=[-float('inf')]+t1s[:-1]
+    guides=[v for k,v in guides.items()]
+    def inner(*,t:float,y:np.ndarray,dt:float,major_step:bool,vehicle:Vehicle):
+        for i,(t0,t1) in enumerate(zip(t0s,t1s)):
+            if t0<=t<t1:
+                return guides[i](t=t,y=y,dt=dt,major_step=major_step,vehicle=vehicle)
+        return np.array([0,0,1])
+    return inner

--- a/src/guidance/pitch_program.py
+++ b/src/guidance/pitch_program.py
@@ -31,7 +31,7 @@ def pitch_program(*, planet: SpicePlanet, y0:np.ndarray, azimuth: float, deg: bo
     tpitch=lambda t:np.interp(t,np.array(ts),np.array(pitches),left=pitch0,right=pitches[-1])
     plt.figure("Pitch program")
     plt.plot(np.arange(0,140,0.1),np.rad2deg(tpitch(np.arange(0,140,0.1))))
-    plt.show()
+    plt.pause(0.1)
     def inner(*, t: float, y: np.ndarray, dt: float, major_step: bool, vehicle: Vehicle):
         pitch=tpitch(t)
         vhatd=np.array([[np.cos(pitch)],

--- a/src/guidance/pitch_program.py
+++ b/src/guidance/pitch_program.py
@@ -1,0 +1,47 @@
+"""
+Pitch program guidance
+
+Created: 1/23/25
+"""
+from typing import Callable
+
+import numpy as np
+from matplotlib import pyplot as plt
+
+from rocket_sim.planet import SpicePlanet
+from rocket_sim.vehicle import Vehicle
+
+
+def pitch_program(*, planet: SpicePlanet, y0:np.ndarray, azimuth: float, deg: bool, t0:float, pitch0: float, tdpitch: list[tuple[float,float]]) ->Callable[...,np.ndarray]:
+    Mjd=planet.downrange_frame(y0[:3],azimuth=azimuth,deg=deg)
+    this_t=t0
+    this_p=pitch0
+    tpitch=[(this_t,this_p)]
+    for ttick,dptick in tdpitch:
+        deltat=ttick-this_t
+        this_t=ttick
+        this_p+=dptick*deltat
+        tpitch.append((this_t,this_p))
+    tpitch=np.array(tpitch)
+    ts=tpitch[:,0]
+    pitches=tpitch[:,1]
+    if deg:
+        pitches=np.deg2rad(pitches)
+        pitch0=np.deg2rad(pitch0)
+    tpitch=lambda t:np.interp(t,np.array(ts),np.array(pitches),left=pitch0,right=pitches[-1])
+    plt.figure("Pitch program")
+    plt.plot(np.arange(0,140,0.1),np.rad2deg(tpitch(np.arange(0,140,0.1))))
+    plt.show()
+    def inner(*, t: float, y: np.ndarray, dt: float, major_step: bool, vehicle: Vehicle):
+        pitch=tpitch(t)
+        vhatd=np.array([[np.cos(pitch)],
+                        [0.0],
+                        [np.sin(pitch)]])
+        vhatj=Mjd @ vhatd
+        if major_step:
+            vehicle.tlm_point.pitch_program_pitch=pitch
+            vehicle.tlm_point.pitch_program_vhatd=vhatd
+            vehicle.tlm_point.pitch_program_vhatd=vhatj
+        return vhatj.reshape(-1)
+    return inner
+

--- a/src/rocket_sim/drag.py
+++ b/src/rocket_sim/drag.py
@@ -160,10 +160,10 @@ def f_drag(*,planet:Planet,clcd:Callable[...,tuple[float,float]],Sref:float)->Ca
                  ...
     """
     def inner(*,t:float,dt:float,y:np.ndarray,vehicle:Vehicle)->np.ndarray:
-        alt=planet.b2lla(rb=y).alt
+        alt=planet.b2lla(rb=y[:3]).alt
         air_props=planet.atm.calc_props(alt)
         rho=air_props.Density
-        wind=np.zeros(3) # Later we will calculate the wind
+        wind=planet.wind(y[:3]).reshape(-1)
         vrel=y[3:]-wind
         vrel_mag=vlength(vrel)
         if vrel_mag==0:

--- a/src/vehicle/titan_3e_centaur.py
+++ b/src/vehicle/titan_3e_centaur.py
@@ -3,9 +3,14 @@ Model of a Titan-III/Centaur (Titan 3E)
 """
 import numpy as np
 
+from guidance.pitch_program import pitch_program
+from rocket_sim.drag import INCHES, f_drag, mach_drag
+from rocket_sim.gravity import SpiceTwoBody, SpiceJ2, SpiceThirdBody
+from rocket_sim.planet import Earth
 from rocket_sim.srm import SRM
+from rocket_sim.universe import Universe
 from rocket_sim.vehicle import Stage, kg_per_lbm, Vehicle, Engine, N_per_lbf, g0
-from vehicle.voyager import Voyager
+from vehicle.voyager import Voyager, init_spice, voyager_et0
 
 
 class Titan3E(Vehicle):
@@ -61,5 +66,49 @@ class Titan3E(Vehicle):
         super().__init__(stages=[self.srbL,self.srbR,self.stage1,self.stage2,
                                 self.interstage_and_shroud,self.centaur,self.pm,self.sc],
                         engines=[(self.srmL,0),(self.srmR,1)])
+
+
+def ascend(*,vgr_id:int):
+    earth=Earth()
+    pad41_lat= 28.583468 # deg, From Google Earth, so on WGS-84
+    pad41_lon=-80.582876
+    pad41_alt=0 # Hashtag Florida
+    y0=earth.launchpad(lat=pad41_lat,lon=pad41_lon,alt=pad41_alt,deg=True,et=voyager_et0[vgr_id])
+    titan3E = Titan3E(tc_id=vgr_id+5)
+    # Flight azimuth from TC-6 report section IV
+    titan3E.guide = pitch_program(planet=earth, y0=y0, azimuth=90.0, deg=True,
+                                  t0=0.0, pitch0=92.0,
+                                  tdpitch=[( 10.0, -1.17),
+                                           ( 20.0, -0.53),
+                                           ( 30.0, -0.73),
+                                           ( 62.0, -0.63),
+                                           ( 75.0, -0.52),
+                                           ( 95.0, -0.38),
+                                           (114.0,  0.00),
+                                           (130.0, -0.75),
+                                           (140.0, -0.08)])
+    print(titan3E.stages)
+    print(titan3E.engines)
+    earth_twobody = SpiceTwoBody(spiceid=399)
+    earth_j2 = SpiceJ2(spiceid=399)
+    moon = SpiceThirdBody(spice_id_center=399, spice_id_body=301, et0=voyager_et0[vgr_id])
+    sun = SpiceThirdBody(spice_id_center=399, spice_id_body=10, et0=voyager_et0[vgr_id])
+    Sref=np.pi*(7*12*INCHES)**2+2*np.pi*(60*INCHES)**2
+    drag=f_drag(planet=earth, clcd=mach_drag(), Sref=Sref)
+    sim = Universe(vehicles=[titan3E],
+                   accs=[earth_twobody, earth_j2, moon, sun],
+                   forces=[],
+                   t0=0, y0s=[y0], fps=10)
+    sim.runto(t1=130.0)
+    #plot_tlm(titan3E, tc_id=titan3E.tc_id)
+
+
+def main():
+    init_spice()
+    ascend(vgr_id=1)
+
+
+if __name__=="__main__":
+    main()
 
 

--- a/src/vehicle/voyager.py
+++ b/src/vehicle/voyager.py
@@ -6,11 +6,8 @@ Created: 1/19/25
 import re
 from collections import namedtuple
 from math import isclose
-from typing import Callable
 
 import numpy as np
-from kwanmath.geodesy import llr2xyz
-from kwanmath.vector import vnormalize, vcross, vdot
 from spiceypy import furnsh, gdpool, str2et
 
 from rocket_sim.vehicle import Vehicle, Stage, Engine, kg_per_lbm, g0, N_per_lbf
@@ -146,96 +143,6 @@ class Voyager(Vehicle):
         for i_engine,(e,b) in self.i_eb.items():
             self.engines[i_engine].throttle=1 if self.t_cb[b,0]<=t<self.t_cb[b,1] else 0
         self.stages[0].attached=(t<self.tsep_pm)
-
-
-def prograde_guide(*,t:float,y:np.ndarray,dt:float,major_step:bool,vehicle:Vehicle):
-    # Prograde
-    return y[3:]/np.linalg.norm(y[3:])
-
-
-def inertial_guide(*,lon:float|None=None,lat:float|None=None,v:float|None=None):
-    if v is None:
-        lon=np.deg2rad(lon)
-        lat=np.deg2rad(lat)
-        v=np.array([np.cos(lon)*np.cos(lat),np.sin(lon)*np.cos(lat),np.sin(lat)])
-    def inner(*,t:float,y:np.ndarray,dt:float,major_step:bool,vehicle:Vehicle):
-        return v
-    return inner
-
-
-def yaw_rate_guide(*,r0:np.ndarray,v0:np.ndarray,dpitch:float,dyaw:float,yawrate:float,t0:float)->Callable[...,np.ndarray]:
-    # Pre-calculate as much as we can
-    # We are going to define our variation from prograde in the VNC frame:
-    #  (V)elocity vector is along first axis
-    #  (N)ormal vector is perpendicular to orbit plane and therefore parallel to r x v
-    #  (C)o-normal is perpendicular to the other two and as close to parallel to r as is reasonable.
-    # Figure these basis vectors as the appear in ICRF
-    rbar = vnormalize(r0.reshape(-1, 1))  # Just for legibility purposes -- rbar is not a basis vector.
-    vbar = vnormalize(v0.reshape(-1, 1))
-    nbar = vnormalize(vcross(rbar, vbar))
-    cbar = vnormalize(vcross(vbar, nbar))
-    assert vdot(rbar, cbar) > 0, 'cbar is the wrong direction'
-    # So each column i of a matrix is where basis vector i of the
-    # from system lands in the to system. v is VNC frame, j is ICRF/J2000 frame
-    # This way, the vector <1,0,0> in VNC is prograde, the xy(vn) plane is equatorial
-    # and a "lon/lat" vector in this frame is a yaw=lon and pitch=lat deviation
-    # from prograde.
-    Mjv = np.hstack((vbar, nbar, cbar))
-
-    def inner(*,t:float,y:np.ndarray,dt:float,major_step:bool,vehicle:Vehicle):
-        aim_v = llr2xyz(lon=dyaw+yawrate*(t-t0), lat=dpitch, r=1, deg=True)
-        aim_j = Mjv @ aim_v
-        return aim_j.reshape(-1)
-    return inner
-
-
-def dprograde_guide(*,dpitch:float,dyaw:float,pitchrate:float,t0:float)->Callable[...,np.ndarray]:
-    """
-    Guidance program that applies a pitch and yaw to prograde guidance
-    :param dpitch:
-    :param dyaw:
-    :return: guidance routine which has the given pitch and yaw offset from
-             prograde in the instantaneous VNC frame
-    """
-    def inner(*,t:float,y:np.ndarray,dt:float,major_step:bool,vehicle:Vehicle):
-        # Can't pre-calculate because we want to use instantaneous prograde direction
-        # We are going to define our variation from prograde in the VNC frame:
-        # Figure these basis vectors as the appear in ICRF
-        rbar = vnormalize(y[:3].reshape(-1, 1))  # Just for checking purposes -- rbar is not a basis vector.
-        vbar = vnormalize(y[3:].reshape(-1, 1))
-        nbar = vnormalize(vcross(rbar, vbar))
-        cbar = vnormalize(vcross(vbar, nbar))
-        # Verify that cbar is roughly up
-        assert vdot(rbar, cbar) > 0, 'cbar is the wrong direction'
-        # So each column i of a matrix is where basis vector i of the
-        # from system lands in the to system. v is VNC frame, j is ICRF/J2000 frame
-        # This way, the vector <1,0,0> in VNC is prograde, the xy(vn) plane is equatorial
-        # and a "lon/lat" vector in this frame is a yaw=lon and pitch=lat deviation
-        # from prograde.
-        Mjv = np.hstack((vbar, nbar, cbar))
-        aim_v = llr2xyz(lon=dyaw, lat=dpitch+pitchrate*(t-t0), r=1, deg=True)
-        aim_j = Mjv @ aim_v
-        return aim_j.reshape(-1)
-    return inner
-
-
-def seq_guide(guides:dict[float,Callable[...,np.ndarray]]):
-    """
-    Create a guidance program that sequences a bunch of separate guidance programs
-    :param guides: The key is the time that the attached program switches off, the value
-                   is the guidance program active before this time. The last one might
-                   as well be active until float('inf').
-    :return:
-    """
-    t1s=[k for k,v in guides.items()]
-    t0s=[-float('inf')]+t1s[:-1]
-    guides=[v for k,v in guides.items()]
-    def inner(*,t:float,y:np.ndarray,dt:float,major_step:bool,vehicle:Vehicle):
-        for i,(t0,t1) in enumerate(zip(t0s,t1s)):
-            if t0<=t<t1:
-                return guides[i](t=t,y=y,dt=dt,major_step=major_step,vehicle=vehicle)
-        return np.array([0,0,1])
-    return inner
 
 
 # Take first reliable position as 60s after first Horizons data point.

--- a/src/vehicle/voyager_depart_target.py
+++ b/src/vehicle/voyager_depart_target.py
@@ -22,9 +22,11 @@ from scipy.optimize import minimize
 from spiceypy import str2et, pxform, timout
 
 import voyager
+
+from guidance.orbit import dprograde_guide
 from rocket_sim.gravity import SpiceTwoBody, SpiceJ2, SpiceThirdBody
 from rocket_sim.universe import Universe
-from voyager import Voyager, horizons_data, prograde_guide, yaw_rate_guide, seq_guide, \
+from voyager import Voyager, horizons_data, \
     simt_track_prePM, target_a_prePM, target_e_prePM, target_i_prePM, target_lan_prePM, \
     simt_track_park,  target_a_park,  target_e_park, target_i_park, target_c3_park, \
     init_spice, horizons_et, voyager_et0
@@ -63,10 +65,10 @@ def sim_pm(*,dpitch:float=0.0, dthr:float=0.0, dyaw:float=0.0, yawrate:float=0.0
     sc.stages[sc.i_pm].prop_mass=0
     sim.runto(t1=simt_track_prePM[vgr_id])
     print("Final state (simt, ICRF, SI): ")
-    print(f"  simt:  {sc.tlm[-1].t: .13e}  rx:   {sc.tlm[-1].y[0]: .13e}  ry:   {sc.tlm[-1].y[1]: .13e}  rz:   {sc.tlm[-1].y[2]: .13e}")
-    print(f"        {sc.tlm[-1].t.hex()}       {  sc.tlm[-1].y[0].hex()}      {  sc.tlm[-1].y[1].hex()}      {  sc.tlm[-1].y[2].hex()}")
-    print(f"                               vx:   {sc.tlm[-1].y[3]: .13e}  vy:   {sc.tlm[-1].y[4]: .13e}  vz:   {sc.tlm[-1].y[5]: .13e}")
-    print(f"                                    {  sc.tlm[-1].y[3].hex()}       {  sc.tlm[-1].y[4].hex()}       {  sc.tlm[-1].y[5].hex()}")
+    print(f"  simt:  {sc.tlm_points[-1].t: .13e}  rx:   {sc.tlm_points[-1].y0[0]: .13e}  ry:   {sc.tlm_points[-1].y0[1]: .13e}  rz:   {sc.tlm_points[-1].y0[2]: .13e}")
+    print(f"        {sc.tlm_points[-1].t.hex()}       {  sc.tlm_points[-1].y0[0].hex()}      {  sc.tlm_points[-1].y0[1].hex()}      {  sc.tlm_points[-1].y0[2].hex()}")
+    print(f"                               vx:   {sc.tlm_points[-1].y0[3]: .13e}  vy:   {sc.tlm_points[-1].y0[4]: .13e}  vz:   {sc.tlm_points[-1].y0[5]: .13e}")
+    print(f"                                    {  sc.tlm_points[-1].y0[3].hex()}       {  sc.tlm_points[-1].y0[4].hex()}       {  sc.tlm_points[-1].y0[5].hex()}")
     if verbose:
         ts = np.array([x.t for x in sc.tlm])
         states = np.array([x.y for x in sc.tlm])
@@ -126,7 +128,7 @@ def sim_centaur2(*,simt1:float,y1:np.ndarray,dpitch:float, dthr:float, dyaw:floa
     print(f"        {simt1.hex()}       {  y1[0].hex()}      {  y1[1].hex()}      {  y1[2].hex()}")
     print(f"                               vx:   {y1[3]: .13e}  vy:   {y1[4]: .13e}  vz:   {y1[5]: .13e}")
     print(f"                                    {  y1[3].hex()}       {  y1[4].hex()}       {  y1[5].hex()}")
-    sc.guide = voyager.dprograde_guide(dpitch=dpitch, dyaw=dyaw, pitchrate=pitchrate,t0=sc.t_cb[(2,0)])
+    sc.guide = dprograde_guide(dpitch=dpitch, dyaw=dyaw, pitchrate=pitchrate,t0=sc.t_cb[(2,0)])
     # Tweak engine efficiency
     for i,(e,b) in sc.i_eb.items():
         if b==2:
@@ -140,24 +142,23 @@ def sim_centaur2(*,simt1:float,y1:np.ndarray,dpitch:float, dthr:float, dyaw:floa
     sc.stages[sc.i_centaur].prop_mass=0
     sim.runto(t1=sc.t_cb[(2,0)]-10)
     print("State just prior to Centaur burn 2 (simt, ICRF, SI): ")
-    print(f"  simt:  {sc.tlm[-1].t: .13e}  rx:   {sc.tlm[-1].y[0]: .13e}  ry:   {sc.tlm[-1].y[1]: .13e}  rz:   {sc.tlm[-1].y[2]: .13e}")
-    print(f"        {sc.tlm[-1].t.hex()}       {  sc.tlm[-1].y[0].hex()}      {  sc.tlm[-1].y[1].hex()}      {  sc.tlm[-1].y[2].hex()}")
-    print(f"                               vx:   {sc.tlm[-1].y[3]: .13e}  vy:   {sc.tlm[-1].y[4]: .13e}  vz:   {sc.tlm[-1].y[5]: .13e}")
-    print(f"                                    {  sc.tlm[-1].y[3].hex()}       {  sc.tlm[-1].y[4].hex()}       {  sc.tlm[-1].y[5].hex()}")
+    print(f"  simt:  {sc.tlm_points[-1].t: .13e}  rx:   {sc.tlm_points[-1].y0[0]: .13e}  ry:   {sc.tlm_points[-1].y0[1]: .13e}  rz:   {sc.tlm_points[-1].y0[2]: .13e}")
+    print(f"        {sc.tlm_points[-1].t.hex()}       {  sc.tlm_points[-1].y0[0].hex()}      {  sc.tlm_points[-1].y0[1].hex()}      {  sc.tlm_points[-1].y0[2].hex()}")
+    print(f"                               vx:   {sc.tlm_points[-1].y0[3]: .13e}  vy:   {sc.tlm_points[-1].y0[4]: .13e}  vz:   {sc.tlm_points[-1].y0[5]: .13e}")
+    print(f"                                    {  sc.tlm_points[-1].y0[3].hex()}       {  sc.tlm_points[-1].y0[4].hex()}       {  sc.tlm_points[-1].y0[5].hex()}")
     sim.change_fps(fps0)
     sim.runto(t1=simt_track_park[vgr_id])
     print("State just after Centaur burn 1 (simt, ICRF, SI): ")
-    print(f"  simt:  {sc.tlm[-1].t: .13e}  rx:   {sc.tlm[-1].y[0]: .13e}  ry:   {sc.tlm[-1].y[1]: .13e}  rz:   {sc.tlm[-1].y[2]: .13e}")
-    print(f"        {sc.tlm[-1].t.hex()}       {  sc.tlm[-1].y[0].hex()}      {  sc.tlm[-1].y[1].hex()}      {  sc.tlm[-1].y[2].hex()}")
-    print(f"                               vx:   {sc.tlm[-1].y[3]: .13e}  vy:   {sc.tlm[-1].y[4]: .13e}  vz:   {sc.tlm[-1].y[5]: .13e}")
-    print(f"                                    {  sc.tlm[-1].y[3].hex()}       {  sc.tlm[-1].y[4].hex()}       {  sc.tlm[-1].y[5].hex()}")
+    print(f"  simt:  {sc.tlm_points[-1].t: .13e}  rx:   {sc.tlm_points[-1].y0[0]: .13e}  ry:   {sc.tlm_points[-1].y0[1]: .13e}  rz:   {sc.tlm_points[-1].y0[2]: .13e}")
+    print(f"        {sc.tlm_points[-1].t.hex()}       {  sc.tlm_points[-1].y0[0].hex()}      {  sc.tlm_points[-1].y0[1].hex()}      {  sc.tlm_points[-1].y0[2].hex()}")
+    print(f"                               vx:   {sc.tlm_points[-1].y0[3]: .13e}  vy:   {sc.tlm_points[-1].y0[4]: .13e}  vz:   {sc.tlm_points[-1].y0[5]: .13e}")
+    print(f"                                    {  sc.tlm_points[-1].y0[3].hex()}       {  sc.tlm_points[-1].y0[4].hex()}       {  sc.tlm_points[-1].y0[5].hex()}")
     if verbose:
-        ts = np.array([x.t for x in sc.tlm])
-        states = np.array([x.y for x in sc.tlm])
-        masses = np.array([x.mass for x in sc.tlm])
-        thrusts = np.array([x.thrust for x in sc.tlm])
-        accs = thrusts / masses
-        elorbs = [elorb(x.y[:3], x.y[3:], l_DU=voyager.EarthRe, mu=voyager.EarthGM, t0=x.t) for x in sc.tlm]
+        ts = np.array([x.t for x in sc.tlm_points])
+        states = np.array([x.y0 for x in sc.tlm_points])
+        masses = np.array([x.mass for x in sc.tlm_points])
+        accs = np.array([x.a_thr for x in sc.tlm_points])
+        elorbs = [elorb(x.y0[:3], x.y0[3:], l_DU=voyager.EarthRe, mu=voyager.EarthGM, t0=x.t) for x in sc.tlm_points]
         eccs = np.array([elorb.e for elorb in elorbs])
         incs = np.array([np.rad2deg(elorb.i) for elorb in elorbs])
         smis = np.array([elorb.a for elorb in elorbs]) / 1852  # Display in nmi to match document

--- a/src/vehicle/voyager_depart_target.py
+++ b/src/vehicle/voyager_depart_target.py
@@ -405,7 +405,7 @@ def target_centaur2(*,simt1:float,y1:np.ndarray,export:bool=False, fps1:int=10,f
     print("Optimal run: ")
     sc=sim_centaur2(simt1=simt1,y1=y1,**{k:v for k,v in zip(('dpitch','dyaw','dthr','pitchrate'),final_guess)},fps1=fps1,fps0=fps0,verbose=True,vgr_id=vgr_id)
     if export:
-        states=sorted([np.hstack((np.array(x.t),x.y)) for x in sc.tlm], key=lambda x:x[0])
+        states=sorted([np.hstack((np.array(x.t),x.y0)) for x in sc.tlm_points], key=lambda x:x[0])
         decimated_states=[]
         i=0
         di=1


### PR DESCRIPTION
This pull request introduces new guidance programs and refactors existing ones for better organization and functionality. The most significant changes include the addition of new guidance functions, the creation of a pitch program guidance, and the refactoring of guidance-related code from `voyager.py` to more appropriate modules.

New guidance programs and functions:

* Added several new guidance functions in `src/guidance/orbit.py`, including `prograde_guide`, `inertial_guide`, `yaw_rate_guide`, `dprograde_guide`, and `seq_guide`. These functions provide various guidance capabilities for orbital maneuvers.
* Introduced a new pitch program guidance function in `src/guidance/pitch_program.py` to handle pitch maneuvers during ascent.

Refactoring and code organization:

* Refactored `voyager.py` by removing guidance functions and importing them from the new `guidance/orbit.py` module. This improves code organization and separation of concerns. [[1]](diffhunk://#diff-8311354af71ea0fe3cb128145ed9c81a1725ee65a6119d2b837f63445a229c50L9-L13) [[2]](diffhunk://#diff-8311354af71ea0fe3cb128145ed9c81a1725ee65a6119d2b837f63445a229c50L151-L240)
* Updated `src/vehicle/titan_3e_centaur.py` to include the new `pitch_program` guidance function and added an `ascend` function to simulate the ascent phase using the new guidance. [[1]](diffhunk://#diff-7b468a77fc4428a26ac5640a5fb7e7ea819203f30cd32781523fcf7bbb1292c8R6-R13) [[2]](diffhunk://#diff-7b468a77fc4428a26ac5640a5fb7e7ea819203f30cd32781523fcf7bbb1292c8R71-R114)

Telemetry and simulation improvements:

* Bug fix: Modified telemetry output in `src/vehicle/voyager_depart_target.py` to use `tlm_points` instead of `tlm`. [[1]](diffhunk://#diff-dc342f762802e96bbb04f711243f87e2385d8788bbb7114fca20c60996f81ec5L66-R71) [[2]](diffhunk://#diff-dc342f762802e96bbb04f711243f87e2385d8788bbb7114fca20c60996f81ec5L129-R131) [[3]](diffhunk://#diff-dc342f762802e96bbb04f711243f87e2385d8788bbb7114fca20c60996f81ec5L143-R161) [[4]](diffhunk://#diff-dc342f762802e96bbb04f711243f87e2385d8788bbb7114fca20c60996f81ec5L407-R408)