### PR TITLE
34 test drag doesnt work

### DIFF
--- a/src/vehicle/titan_3e_centaur.py
+++ b/src/vehicle/titan_3e_centaur.py
@@ -2,18 +2,11 @@
 Model of a Titan-III/Centaur (Titan 3E)
 """
 import numpy as np
-from kwanmath.vector import vangle
 from matplotlib import pyplot as plt
-from spiceypy import pxform
 
-from guidance.pitch_program import pitch_program
-from rocket_sim.drag import INCHES, f_drag, mach_drag
-from rocket_sim.gravity import SpiceTwoBody, SpiceJ2, SpiceThirdBody
-from rocket_sim.planet import Earth, SpicePlanet
 from rocket_sim.srm import SRM
-from rocket_sim.universe import Universe
 from rocket_sim.vehicle import Stage, kg_per_lbm, Vehicle, Engine, N_per_lbf, g0
-from vehicle.voyager import Voyager, init_spice, voyager_et0
+from vehicle.voyager import Voyager, init_spice
 
 
 class Titan3E(Vehicle):
@@ -70,85 +63,5 @@ class Titan3E(Vehicle):
                                 self.interstage_and_shroud,self.centaur,self.pm,self.sc],
                         engines=[(self.srmL,0),(self.srmR,1)])
 
-
-def plot_tlm(vehicle:Vehicle,tc_id:int,earth:SpicePlanet,
-             launch_lat:float, launch_lon:float, deg:bool,
-             launch_alt:float, launch_et0:float,drag_enabled:bool):
-    ts=np.array([tlm_point.t for tlm_point in vehicle.tlm_points])
-    states=np.array([tlm_point.y0 for tlm_point in vehicle.tlm_points]).T
-    alts=earth.b2lla(states[0:3,:]).alt
-    # Position of the launchpad at each t, for calculating downrange
-    y0b=earth.lla2b(lat_deg=launch_lat,lon_deg=launch_lon,alt=launch_alt)
-    # Make a stack of matrices of shape (N,3,3). Each Mjbs[i,:,:] is
-    # the (3,3) matrix for ts[i].
-    Mjbs=np.array([pxform(earth.bf_frame,'J2000',t+launch_et0) for t in ts])
-    # Transform y0b by each matrix in the stack above. This produces
-    # a result of shape (3,N), one column vector for each time point.
-    y0js=(Mjbs @ y0b)[:,:,0].T #Should be shape (3,N), one column vector for each time point
-    downranges=vangle(y0js,states[0:3,:])*earth.re
-    plt.figure("Vehicle telemetry")
-    plt.subplot(2,2,1)
-    plt.ylabel("Alt/km")
-    plt.plot(ts,alts/1000,label=f'alt {"with drag" if drag_enabled else "no drag"}')
-    plt.legend()
-    plt.subplot(2,2,2)
-    plt.ylabel("Downrange/km")
-    plt.plot(ts,downranges/1000,label=f'alt {"with drag" if drag_enabled else "no drag"}')
-    plt.legend()
-    plt.subplot(2,2,3)
-    plt.ylabel("Alt/km vs Downrange/km")
-    plt.plot(downranges/1000,alts/1000,label=f'traj {"with drag" if drag_enabled else "no drag"}')
-    plt.axis('equal')
-    plt.legend()
-    plt.pause(0.1)
-
-
-def ascend(*,vgr_id:int,drag_enabled:bool):
-    earth=Earth()
-    pad41_lat= 28.583468 # deg, From Google Earth, so on WGS-84
-    pad41_lon=-80.582876
-    pad41_alt=0 # Hashtag Florida
-    et0=voyager_et0[vgr_id]
-    y0=earth.launchpad(lat=pad41_lat,lon=pad41_lon,alt=pad41_alt,deg=True,et=et0)
-    titan3E = Titan3E(tc_id=vgr_id+5)
-    # Flight azimuth from TC-6 report section IV
-    titan3E.guide = pitch_program(planet=earth, y0=y0, azimuth=90.0, deg=True,
-                                  t0=0.0, pitch0=92.0,
-                                  tdpitch=[( 10.0, -1.17),
-                                           ( 20.0, -0.53),
-                                           ( 30.0, -0.73),
-                                           ( 62.0, -0.63),
-                                           ( 75.0, -0.52),
-                                           ( 95.0, -0.38),
-                                           (114.0,  0.00),
-                                           (130.0, -0.75),
-                                           (140.0, -0.08)])
-    print(titan3E.stages)
-    print(titan3E.engines)
-    earth_twobody = SpiceTwoBody(spiceid=399)
-    earth_j2 = SpiceJ2(spiceid=399)
-    moon = SpiceThirdBody(spice_id_center=399, spice_id_body=301, et0=voyager_et0[vgr_id])
-    sun = SpiceThirdBody(spice_id_center=399, spice_id_body=10, et0=voyager_et0[vgr_id])
-    Sref=np.pi*(7*12*INCHES)**2+2*np.pi*(60*INCHES)**2
-    drag=f_drag(planet=earth, clcd=mach_drag(), Sref=Sref)
-    sim = Universe(vehicles=[titan3E],
-                   accs=[earth_twobody, earth_j2, moon, sun],
-                   forces=[drag] if drag_enabled else [],
-                   t0=0, y0s=[y0], fps=10)
-    sim.runto(t1=130.0)
-    plot_tlm(titan3E, tc_id=titan3E.tc_id,earth=earth,
-             launch_lat=pad41_lat,launch_lon=pad41_lon,deg=True,
-             launch_alt=pad41_alt,launch_et0=et0,drag_enabled=drag_enabled)
-
-
-def main():
-    init_spice()
-    ascend(vgr_id=1,drag_enabled=True)
-    ascend(vgr_id=1,drag_enabled=False)
-    plt.show()
-
-
-if __name__=="__main__":
-    main()
 
 

--- a/tests/test_guidance/test_pitch_program.py
+++ b/tests/test_guidance/test_pitch_program.py
@@ -1,0 +1,102 @@
+"""
+Describe purpose of this script here
+
+Created: 1/23/25
+"""
+import pytest
+
+import numpy as np
+from kwanmath.vector import vangle
+from matplotlib import pyplot as plt
+from spiceypy import pxform, kclear
+
+from guidance.pitch_program import pitch_program
+from rocket_sim.drag import INCHES, f_drag, mach_drag
+from rocket_sim.gravity import SpiceTwoBody, SpiceJ2, SpiceThirdBody
+
+from rocket_sim.planet import SpicePlanet, Earth
+from rocket_sim.universe import Universe
+from rocket_sim.vehicle import Vehicle
+from vehicle.titan_3e_centaur import Titan3E
+from vehicle.voyager import voyager_et0, init_spice
+
+
+def plot_tlm(vehicle:Vehicle,tc_id:int,earth:SpicePlanet,
+             launch_lat:float, launch_lon:float, deg:bool,
+             launch_alt:float, launch_et0:float,drag_enabled:bool):
+    ts=np.array([tlm_point.t for tlm_point in vehicle.tlm_points])
+    states=np.array([tlm_point.y0 for tlm_point in vehicle.tlm_points]).T
+    alts=earth.b2lla(states[0:3,:]).alt
+    # Position of the launchpad at each t, for calculating downrange
+    y0b=earth.lla2b(lat_deg=launch_lat,lon_deg=launch_lon,alt=launch_alt)
+    # Make a stack of matrices of shape (N,3,3). Each Mjbs[i,:,:] is
+    # the (3,3) matrix for ts[i].
+    Mjbs=np.array([pxform(earth.bf_frame,'J2000',t+launch_et0) for t in ts])
+    # Transform y0b by each matrix in the stack above. This produces
+    # a result of shape (3,N), one column vector for each time point.
+    y0js=(Mjbs @ y0b)[:,:,0].T #Should be shape (3,N), one column vector for each time point
+    downranges=vangle(y0js,states[0:3,:])*earth.re
+    plt.figure("Vehicle telemetry")
+    plt.subplot(2,2,1)
+    plt.ylabel("Alt/km")
+    plt.plot(ts,alts/1000,label=f'alt {"with drag" if drag_enabled else "no drag"}')
+    plt.legend()
+    plt.subplot(2,2,2)
+    plt.ylabel("Downrange/km")
+    plt.plot(ts,downranges/1000,label=f'alt {"with drag" if drag_enabled else "no drag"}')
+    plt.legend()
+    plt.subplot(2,2,3)
+    plt.ylabel("Alt/km vs Downrange/km")
+    plt.plot(downranges/1000,alts/1000,label=f'traj {"with drag" if drag_enabled else "no drag"}')
+    plt.axis('equal')
+    plt.legend()
+    plt.pause(0.1)
+
+
+@pytest.fixture
+def kernels():
+    init_spice()
+    yield None
+    kclear()
+
+
+@pytest.mark.parametrize(
+   "vgr_id,drag_enabled",
+    [(1,True),(1,False)]
+)
+def test_titan3E_pitch_program_spheroid_drag(kernels,vgr_id:int,drag_enabled:bool):
+    earth=Earth()
+    pad41_lat= 28.583468 # deg, From Google Earth, so on WGS-84
+    pad41_lon=-80.582876
+    pad41_alt=0 # Hashtag Florida
+    et0=voyager_et0[vgr_id]
+    y0=earth.launchpad(lat=pad41_lat,lon=pad41_lon,alt=pad41_alt,deg=True,et=et0)
+    titan3E = Titan3E(tc_id=vgr_id+5)
+    # Flight azimuth from TC-6 report section IV
+    titan3E.guide = pitch_program(planet=earth, y0=y0, azimuth=90.0, deg=True,
+                                  t0=0.0, pitch0=92.0,
+                                  tdpitch=[( 10.0, -1.17),
+                                           ( 20.0, -0.53),
+                                           ( 30.0, -0.73),
+                                           ( 62.0, -0.63),
+                                           ( 75.0, -0.52),
+                                           ( 95.0, -0.38),
+                                           (114.0,  0.00),
+                                           (130.0, -0.75),
+                                           (140.0, -0.08)])
+    print(titan3E.stages)
+    print(titan3E.engines)
+    earth_twobody = SpiceTwoBody(spiceid=399)
+    earth_j2 = SpiceJ2(spiceid=399)
+    moon = SpiceThirdBody(spice_id_center=399, spice_id_body=301, et0=voyager_et0[vgr_id])
+    sun = SpiceThirdBody(spice_id_center=399, spice_id_body=10, et0=voyager_et0[vgr_id])
+    Sref=np.pi*(7*12*INCHES)**2+2*np.pi*(60*INCHES)**2
+    drag=f_drag(planet=earth, clcd=mach_drag(), Sref=Sref)
+    sim = Universe(vehicles=[titan3E],
+                   accs=[earth_twobody, earth_j2, moon, sun],
+                   forces=[drag] if drag_enabled else [],
+                   t0=0, y0s=[y0], fps=10)
+    sim.runto(t1=130.0)
+    plot_tlm(titan3E, tc_id=titan3E.tc_id,earth=earth,
+             launch_lat=pad41_lat,launch_lon=pad41_lon,deg=True,
+             launch_alt=pad41_alt,launch_et0=et0,drag_enabled=drag_enabled)

--- a/tests/test_rocket_sim/test_drag.py
+++ b/tests/test_rocket_sim/test_drag.py
@@ -70,4 +70,3 @@ def test_drag():
             ])
             range.runto(t1=130.0)
         plot_tlm(titan3E,tc_id=1 if drag_enabled else 0)
-    plt.show()

--- a/tests/test_rocket_sim/test_drag.py
+++ b/tests/test_rocket_sim/test_drag.py
@@ -50,7 +50,7 @@ class FlatWorld(Planet):
     def __init__(self,*,atm:Atmosphere):
         super().__init__(atm=atm,w0=0.0,mu=1.0,re=1000.0,f=0.0)
     def b2lla(self,rb:np.array,centric:bool=False,deg:bool=False):
-        return namedtuple('xyz2lla', ['lat', 'lon', 'alt'])(0,0,rb[3])
+        return namedtuple('xyz2lla', ['lat', 'lon', 'alt'])(0,0,rb[2])
 
 
 

--- a/tests/test_rocket_sim/test_drag.py
+++ b/tests/test_rocket_sim/test_drag.py
@@ -48,7 +48,7 @@ def plot_tlm(vehicle:Vehicle,tc_id:int):
 
 class FlatWorld(Planet):
     def __init__(self,*,atm:Atmosphere):
-        super().__init__(M0_rb=None,atm=atm,w0=0.0,mu=1.0,re=1000.0,f=0.0)
+        super().__init__(atm=atm,w0=0.0,mu=1.0,re=1000.0,f=0.0)
     def b2lla(self,rb:np.array,centric:bool=False,deg:bool=False):
         return namedtuple('xyz2lla', ['lat', 'lon', 'alt'])(0,0,rb[3])
 

--- a/tests/test_rocket_sim/test_gravity.py
+++ b/tests/test_rocket_sim/test_gravity.py
@@ -18,7 +18,6 @@ def plot_tlm(vehicle:Vehicle):
     plt.figure("pos")
     plt.plot(states[:,0],states[:,1],label='r')
     plt.axis('equal')
-    plt.show()
 
 
 @pytest.fixture

--- a/tests/test_rocket_sim/test_vehicle.py
+++ b/tests/test_rocket_sim/test_vehicle.py
@@ -41,7 +41,7 @@ def plot_tlm(vehicle:Vehicle):
     plt.plot(states[:,5],label='vz')
     plt.figure("pos")
     plt.plot(states[:,2],label='rz')
-    plt.show()
+    plt.pause(0.1)
 
 
 Voyager1=Vehicle(stages=[Voyager1Stage,PMStage],engines=[(PMEngine,1)])

--- a/tests/test_vehicle/test_titan_3e_centaur.py
+++ b/tests/test_vehicle/test_titan_3e_centaur.py
@@ -12,7 +12,7 @@ from rocket_sim.universe import VerticalRange, TestStand
 from rocket_sim.vehicle import Vehicle, g0
 from vehicle.titan_3e_centaur import Titan3E
 
-def plot_tlm(vehicle:Vehicle,tc_id:int):
+def plot_tlm_vertical(vehicle:Vehicle,tc_id:int):
     ts=np.array([tlm_point.t for tlm_point in vehicle.tlm_points])
     states=np.array([tlm_point.y0 for tlm_point in vehicle.tlm_points])
     masses=np.array([tlm_point.mass for tlm_point in vehicle.tlm_points])
@@ -51,5 +51,7 @@ def test_titan3E(static:bool):
         else:
             range=VerticalRange(vehicles=[titan3E],fps=10,forces=[])
             range.runto(t1=130.0)
-        plot_tlm(titan3E,tc_id=tc_id)
-    plt.show()
+        plot_tlm_vertical(titan3E,tc_id=tc_id)
+    plt.pause(0.1)
+
+


### PR DESCRIPTION
Fixed the test_drag() test so it works. Also moved Titan 3E pitch program exercise into test_pitch_program.py and changed a bunch of plt.show() to plt.pause(). All current tests work.

Refactoring and cleanup:

* [`src/vehicle/titan_3e_centaur.py`](diffhunk://#diff-7b468a77fc4428a26ac5640a5fb7e7ea819203f30cd32781523fcf7bbb1292c8L5-R9): Removed unused imports and functions including `plot_tlm`, `ascend`, and `main`. [[1]](diffhunk://#diff-7b468a77fc4428a26ac5640a5fb7e7ea819203f30cd32781523fcf7bbb1292c8L5-R9) [[2]](diffhunk://#diff-7b468a77fc4428a26ac5640a5fb7e7ea819203f30cd32781523fcf7bbb1292c8L74-L153)

Migration of functions to test files:

* [`tests/test_guidance/test_pitch_program.py`](diffhunk://#diff-9f0babd8c72c1e94f4a90b45af6f9ad99e1bf07dddbbaf4be00c696b974c16d6R1-R102): Added new test file with the `plot_tlm` function and tests for the `Titan3E` pitch program.
* [`tests/test_vehicle/test_titan_3e_centaur.py`](diffhunk://#diff-56d9e5b30109e1e616f8f45e4c975dd4f640ed96936a2fe6ea7fd585c3b7c26fL15-R15): Renamed `plot_tlm` to `plot_tlm_vertical` and updated `test_titan3E` to use `plot_tlm_vertical`. [[1]](diffhunk://#diff-56d9e5b30109e1e616f8f45e4c975dd4f640ed96936a2fe6ea7fd585c3b7c26fL15-R15) [[2]](diffhunk://#diff-56d9e5b30109e1e616f8f45e4c975dd4f640ed96936a2fe6ea7fd585c3b7c26fL54-R57)

Changes in plotting behavior:

* [`tests/test_rocket_sim/test_gravity.py`](diffhunk://#diff-474435737e4f28672e453d8282e6b5ecfda17905b1d1bf6471b16016a0f3dee3L21): Removed `plt.show()` from the `plot_tlm` function.
* [`tests/test_rocket_sim/test_vehicle.py`](diffhunk://#diff-f844688b6e9b0a06f0c28d3ac259f98d38b05cb8bec79f19c9dc030ff42dd586L44-R44): Replaced `plt.show()` with `plt.pause(0.1)` in the `plot_tlm` function.
* [`tests/test_rocket_sim/test_drag.py`](diffhunk://#diff-d736d4d1139d49b2accf90616743923fafc5fc8e4b4fbd8451f115f73a82ed62L73): Removed `plt.show()` from the `test_drag` function.